### PR TITLE
Fixes to avoid multiple definitions for thread pools and suppress compiler warnings.

### DIFF
--- a/include/ips4o/bucket_pointers.hpp
+++ b/include/ips4o/bucket_pointers.hpp
@@ -60,9 +60,7 @@ class Sorter<Cfg>::BucketPointers {
 
 #elif defined(__SIZEOF_INT128__)
 
-    // __extension__ suppresses the pedantic warning about __int128
-    // not being ISO C++ compliant
-    __extension__ using atomic_type = unsigned __int128;
+    using atomic_type = __uint128_t;
 
 #endif  // defined( __SIZEOF_INT128__)
 

--- a/include/ips4o/bucket_pointers.hpp
+++ b/include/ips4o/bucket_pointers.hpp
@@ -60,7 +60,9 @@ class Sorter<Cfg>::BucketPointers {
 
 #elif defined(__SIZEOF_INT128__)
 
-    using atomic_type = unsigned __int128;
+    // __extension__ suppresses the pedantic warning about __int128
+    // not being ISO C++ compliant
+    __extension__ using atomic_type = unsigned __int128;
 
 #endif  // defined( __SIZEOF_INT128__)
 

--- a/include/ips4o/classifier.hpp
+++ b/include/ips4o/classifier.hpp
@@ -35,7 +35,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <type_traits>
 #include <utility>
 
@@ -127,7 +126,7 @@ class Sorter<Cfg>::Classifier {
   template <bool kEqualBuckets, class Yield, int...Args>
   void classifySwitch(iterator begin, iterator end, Yield&& yield,
 		      std::integer_sequence<int, Args...>) const {
-    IPS4OML_ASSUME_NOT(log_buckets_ <= 0 && log_buckets_ >= static_cast<std::int64_t>(sizeof...(Args)));
+    IPS4OML_ASSUME_NOT(log_buckets_ <= 0 && log_buckets_ >= static_cast<int>(sizeof...(Args)));
     ((Args == log_buckets_ &&
       classifyUnrolled<kEqualBuckets, Args>(begin, end, std::forward<Yield>(yield)))
      || ...);

--- a/include/ips4o/classifier.hpp
+++ b/include/ips4o/classifier.hpp
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <type_traits>
 #include <utility>
 
@@ -126,7 +127,7 @@ class Sorter<Cfg>::Classifier {
   template <bool kEqualBuckets, class Yield, int...Args>
   void classifySwitch(iterator begin, iterator end, Yield&& yield,
 		      std::integer_sequence<int, Args...>) const {
-    IPS4OML_ASSUME_NOT(log_buckets_ <= 0 && log_buckets_ >= sizeof...(Args));
+    IPS4OML_ASSUME_NOT(log_buckets_ <= 0 && log_buckets_ >= static_cast<std::int64_t>(sizeof...(Args)));
     ((Args == log_buckets_ &&
       classifyUnrolled<kEqualBuckets, Args>(begin, end, std::forward<Yield>(yield)))
      || ...);

--- a/include/ips4o/ips4o_fwd.hpp
+++ b/include/ips4o/ips4o_fwd.hpp
@@ -153,7 +153,7 @@ class Sorter {
     std::pair<int, bool> partition(iterator begin, iterator end, diff_t* bucket_start,
                                    int my_id, int num_threads);
 
-    void processSmallTasks(iterator begin, int num_threads);
+    void processSmallTasks(iterator begin);
 
     void processBigTasks(const iterator begin, const diff_t stripe, const int my_id,
                          BufferStorage& buffer_storage,
@@ -162,7 +162,7 @@ class Sorter {
     void processBigTaskPrimary(const iterator begin, const diff_t stripe, const int my_id,
                                BufferStorage& buffer_storage,
                                std::vector<std::shared_ptr<SubThreadPool>>& tp_trash);
-    void processBigTasksSecondary(const int my_id, BufferStorage& buffer_storage);
+    void processBigTasksSecondary(const int my_id);
 
     void queueTasks(const diff_t stripe, const int id, const int num_threads,
                     const diff_t parent_task_size, const diff_t offset,

--- a/include/ips4o/parallel.hpp
+++ b/include/ips4o/parallel.hpp
@@ -65,6 +65,7 @@ namespace detail {
  */
 template <class Cfg>
 void Sorter<Cfg>::processSmallTasks(const iterator begin, int num_threads) {
+    (void)num_threads;
     auto& scheduler = shared_->scheduler;
     auto& my_queue = local_.seq_task_queue;
     Task task;
@@ -185,6 +186,7 @@ void Sorter<Cfg>::setShared(SharedData* shared) {
  */
 template <class Cfg>
 void Sorter<Cfg>::processBigTasksSecondary(const int id, BufferStorage& buffer_storage) {
+    (void)buffer_storage;
     BigTask& task = shared_->big_tasks[id];
     auto partial_thread_pool = shared_->thread_pools[task.root_thread];
 
@@ -281,6 +283,7 @@ std::pair<std::vector<typename Cfg::difference_type>, bool>
 Sorter<Cfg>::parallelPartitionPrimary(const iterator begin, const iterator end,
                                       const int num_threads) {
     const auto size = end - begin;
+    (void)size;
 
     const auto res = partition<true>(begin, end, shared_->bucket_start, 0, num_threads);
     const int num_buckets = std::get<0>(res);
@@ -395,6 +398,7 @@ class ParallelSorter {
 
         // Set up base data before switching to parallel mode
         auto& shared = shared_ptr_.get();
+        (void)shared;
 
         // Execute in parallel
         thread_pool_(

--- a/include/ips4o/thread_pool.hpp
+++ b/include/ips4o/thread_pool.hpp
@@ -170,7 +170,7 @@ class StdThreadPool {
 /**
  * Constructor for the std::thread pool.
  */
-StdThreadPool::Impl::Impl(int num_threads)
+inline StdThreadPool::Impl::Impl(int num_threads)
     : sync_(std::max(1, num_threads))
     , pool_barrier_(std::max(1, num_threads))
     , num_threads_(num_threads)
@@ -184,7 +184,7 @@ StdThreadPool::Impl::Impl(int num_threads)
 /**
  * Destructor for the std::thread pool.
  */
-StdThreadPool::Impl::~Impl() {
+inline StdThreadPool::Impl::~Impl() {
     done_ = true;
     pool_barrier_.barrier();
     for (auto& t : threads_)
@@ -195,7 +195,7 @@ StdThreadPool::Impl::~Impl() {
  * Entry point for parallel execution for the std::thread pool.
  */
 template <class F>
-void StdThreadPool::Impl::run(F&& func, int num_threads) {
+inline void StdThreadPool::Impl::run(F&& func, int num_threads) {
     func_ = func;
     num_threads_ = num_threads;
     sync_.setNumThreads(num_threads);
@@ -208,7 +208,7 @@ void StdThreadPool::Impl::run(F&& func, int num_threads) {
 /**
  * Main loop for threads created by the std::thread pool.
  */
-void StdThreadPool::Impl::main(const int my_id) {
+inline void StdThreadPool::Impl::main(const int my_id) {
     for (;;) {
         pool_barrier_.barrier();
         if (done_) break;
@@ -276,13 +276,13 @@ class ThreadJoiningThreadPool {
 /**
  * Constructor for the std::thread pool.
  */
-ThreadJoiningThreadPool::Impl::Impl(int num_threads)
+inline ThreadJoiningThreadPool::Impl::Impl(int num_threads)
     : sync_(num_threads), pool_barrier_(num_threads), num_threads_(num_threads) {}
 
 /**
  * Destructor for the std::thread pool.
  */
-ThreadJoiningThreadPool::Impl::~Impl() { assert(done_ == true); }
+inline ThreadJoiningThreadPool::Impl::~Impl() { assert(done_ == true); }
 
 /**
  * Entry point for parallel execution for the std::thread pool.
@@ -301,7 +301,7 @@ void ThreadJoiningThreadPool::Impl::run(F&& func, int num_threads) {
 /**
  * Main loop for threads which have joined.
  */
-void ThreadJoiningThreadPool::Impl::main(const int my_id) {
+inline void ThreadJoiningThreadPool::Impl::main(const int my_id) {
     for (;;) {
         pool_barrier_.barrier();
         if (done_) break;
@@ -311,9 +311,9 @@ void ThreadJoiningThreadPool::Impl::main(const int my_id) {
     }
 }
 
-void ThreadJoiningThreadPool::Impl::join(int my_id) { main(my_id); }
+inline void ThreadJoiningThreadPool::Impl::join(int my_id) { main(my_id); }
 
-void ThreadJoiningThreadPool::Impl::release_threads() {
+inline void ThreadJoiningThreadPool::Impl::release_threads() {
     done_ = true;
     pool_barrier_.barrier();
 }


### PR DESCRIPTION
When using the ips4o parallel sort via normal Makefiles, I ran into multiple definition errors when compiling associated with the various *ThreadPool Impl structs. I inlined all the associated functions where the definition was separated from the declaration, which resolved the errors. This is the first commit in the PR.

In addition, I attempted to suppress most of the (presumably spurious) compiler warnings when including the ips4o headers. (I did this for `-Wall -Wextra -Wpedantic`, but I typically don't use pedantic so I don't actually care about the warnings associated with `__int128`.) The remaining warning, as far as I get them at least, is associated with `classifier.h:131`:
```
./lib/ips4o/include/ips4o/classifier.hpp:131:28: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
```
I attempted to add parentheses and such to make this warning go away, but the compiler seems to be hung up on something here. I don't fully understand the control flow of this function, but if you can explain it to me or have some ideas regarding the warning, I would be happy to take another look at the warning and try and suppress it.

Thanks for your time and feedback!