### PR TITLE
Removed submodule for legacy find modules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/cmake-modules"]
-	path = extern/cmake-modules
-	url = https://github.com/ips4o/legacy-modules.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ if (NOT IPS4O_DISABLE_PARALLEL)
   find_package (Threads REQUIRED)
   target_link_libraries(ips4o INTERFACE Threads::Threads)
 
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/extern/cmake-modules)
   find_package(TBB REQUIRED)
   target_link_libraries(ips4o INTERFACE TBB::tbb)
 


### PR DESCRIPTION
This was only used for finding TBB, but the FindTBB module was outdated, so that it failed on current systems.

Now TBB supports CMake out of the box and the files for that are shipped on all major operating systems.