### PR TITLE
Use std::iter_swap in selectSample to support custom iterators

### DIFF
--- a/include/ips4o/sampling.hpp
+++ b/include/ips4o/sampling.hpp
@@ -54,13 +54,11 @@ template <class It, class RandomGen>
 void selectSample(It begin, const It end,
                   typename std::iterator_traits<It>::difference_type num_samples,
                   RandomGen&& gen) {
-    using std::swap;
-
     auto n = end - begin;
     while (num_samples--) {
         const auto i = std::uniform_int_distribution<
                 typename std::iterator_traits<It>::difference_type>(0, --n)(gen);
-        swap(*begin, begin[i]);
+        std::iter_swap(begin, begin + i);
         ++begin;
     }
 }


### PR DESCRIPTION
When trying to use IPS4o sort with custom iterator/reference types we need to swap the values at the iterator location. Currently this would fail with errors like
```
error: cannot bind non-const lvalue reference of type ‘MyReference&’ to an rvalue of type ‘MyIterator::reference’ {aka ‘MyReference’}
```
Using `std::iter_swap` instead of `std::swap` is more idiomatic C++ code and allows us to override it for our custom iterator and reference type.

Here's an example to give some more background. When I implemented a custom iterator to sort with IPS4o I ran into this compilation issue:
```
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_algobase.h: In instantiation of ‘void std::iter_swap(_ForwardIterator1, _ForwardIterator2) [with _ForwardIterator1 = MyIterator; _ForwardIterator2 = MyIterator]’:
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_algo.h:1110:18:   required from ‘void std::__reverse(_RandomAccessIterator, _RandomAccessIterator, random_access_iterator_tag) [with _RandomAccessIterator = MyIterator]’
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_algo.h:1137:21:   required from ‘void std::reverse(_BIter, _BIter) [with _BIter = MyIterator]’
/codemill/bessen/opensource/ips4o/include/ips4o/base_case.hpp:117:21:   required from ‘bool ips4o::detail::sortSimpleCases(It, It, Comp&&) [with It = MyIterator; Comp = MyLess&]’
/codemill/bessen/opensource/ips4o/include/ips4o/ips4o.hpp:70:32:   required from ‘void ips4o::sort(It, It, Comp) [with Cfg = Config<>; It = MyIterator; Comp = MyLess]’
/codemill/bessen/opensource/ips4o/include/ips4o/ips4o.hpp:168:25:   required from ‘void ips4o::parallel::sort(It, It, Comp, int) [with Cfg = ips4o::Config<>; It = MyIterator; Comp = MyLess]’
/codemill/bessen/opensource/ips4o/include/ips4o/ips4o.hpp:178:36:   required from ‘void ips4o::parallel::sort(It, It, Comp) [with It = MyIterator; Comp = MyLess]’
/codemill/bessen/opensource/ips4o/src/example.cpp:328:30:   required from here
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_algobase.h:185:11: error: no matching function for call to ‘swap(MyIterator::reference, MyIterator::reference)’
  185 |       swap(*__a, *__b);
      |       ~~~~^~~~~~~~~~~~
/codemill/bessen/opensource/ips4o/src/example.cpp:293:13: note: candidate: ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = MyReference; _Require<__not_<__is_tuple_like<_Tp> >, is_move_constructible<_Tp>, is_move_assignable<_Tp> > = void]’ (near match)
  293 | inline void std::swap(MyReference &r1, MyReference &r2) {
      |             ^~~
/codemill/bessen/opensource/ips4o/src/example.cpp:293:13: note:   conversion of argument 2 would be ill-formed:
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_algobase.h:185:11: error: cannot bind non-const lvalue reference of type ‘MyReference&’ to an rvalue of type ‘MyIterator::reference’ {aka ‘MyReference’}
  185 |       swap(*__a, *__b);
      |       ~~~~^~~~~~~~~~~~
```
The correct fix here would probably be to modify the standard library `std::iter_swap` function to introduce temporary variables for `*a` and `*b` to make them rvalues. Instead I opted to fix that problem by creating a specialized `std::iter_swap` implementation:
```
template<>
inline void std::iter_swap(MyIterator it1, MyIterator it2) {
    it1.swap(it2);
}
```
After that I now ran into another related error:
```
/codemill/bessen/opensource/ips4o/include/ips4o/sampling.hpp: In instantiation of ‘void ips4o::detail::selectSample(It, It, typename std::iterator_traits<_Iter>::difference_type, RandomGen&&) [with It = MyIterator; RandomGen = std::linear_congruential_engine<long unsigned int, 6364136223846793005, 1442695040888963407, 0>&; typename std::iterator_traits<_Iter>::difference_type = long int]’:
/codemill/bessen/opensource/ips4o/include/ips4o/sampling.hpp:84:25:   required from ‘std::pair<int, bool> ips4o::detail::Sorter<Cfg>::buildClassifier(iterator, iterator, Classifier&) [with Cfg = ips4o::ExtendedConfig<MyIterator, MyLess, ips4o::Config<>, ips4o::OpenMPThreadPool>; iterator = MyIterator]’
/codemill/bessen/opensource/ips4o/include/ips4o/partitioning.hpp:71:21:   required from ‘std::pair<int, bool> ips4o::detail::Sorter<Cfg>::partition(iterator, iterator, diff_t*, int, int) [with bool kIsParallel = true; Cfg = ips4o::ExtendedConfig<MyIterator, MyLess, ips4o::Config<>, ips4o::OpenMPThreadPool>; iterator = MyIterator; diff_t = long int]’
/codemill/bessen/opensource/ips4o/include/ips4o/parallel.hpp:323:37:   required from ‘void ips4o::detail::Sorter<Cfg>::parallelSortPrimary(iterator, iterator, int, BufferStorage&, std::vector<std::shared_ptr<typename Cfg::SubThreadPool> >&) [with Cfg = ips4o::ExtendedConfig<MyIterator, MyLess, ips4o::Config<>, ips4o::OpenMPThreadPool>; iterator = MyIterator; typename Cfg::SubThreadPool = ips4o::ThreadJoiningThreadPool]’
/codemill/bessen/opensource/ips4o/include/ips4o/parallel.hpp:406:51:   required from ‘void ips4o::ParallelSorter<Cfg>::operator()(iterator, iterator) [with Cfg = ips4o::ExtendedConfig<MyIterator, MyLess, ips4o::Config<>, ips4o::OpenMPThreadPool>; iterator = MyIterator]’
/codemill/bessen/opensource/ips4o/include/ips4o/ips4o.hpp:155:15:   required from ‘std::enable_if_t<std::is_class<typename std::remove_reference<ThreadPool>::type>::value> ips4o::parallel::sort(It, It, Comp, ThreadPool&&) [with Cfg = ips4o::Config<>; It = MyIterator; Comp = MyLess; ThreadPool = ips4o::OpenMPThreadPool; std::enable_if_t<std::is_class<typename std::remove_reference<ThreadPool>::type>::value> = void; typename std::remove_reference<ThreadPool>::type = ips4o::OpenMPThreadPool]’
/codemill/bessen/opensource/ips4o/include/ips4o/ips4o.hpp:170:35:   required from ‘void ips4o::parallel::sort(It, It, Comp, int) [with Cfg = ips4o::Config<>; It = MyIterator; Comp = MyLess]’
/codemill/bessen/opensource/ips4o/include/ips4o/ips4o.hpp:178:36:   required from ‘void ips4o::parallel::sort(It, It, Comp) [with It = MyIterator; Comp = MyLess]’
/codemill/bessen/opensource/ips4o/src/example.cpp:328:30:   required from here
/codemill/bessen/opensource/ips4o/include/ips4o/sampling.hpp:63:13: error: no matching function for call to ‘swap(MyIterator::reference, MyIterator::reference)’
   63 |         swap(*begin, begin[i]);
      |         ~~~~^~~~~~~~~~~~~~~~~~
In file included from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_pair.h:61,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_algobase.h:64,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/algorithm:60,
                 from /codemill/bessen/opensource/ips4o/src/example.cpp:35:
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/move.h:189:5: note: candidate: ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = MyReference; _Require<__not_<__is_tuple_like<_Tp> >, is_move_constructible<_Tp>, is_move_assignable<_Tp> > = void]’ (near match)
  189 |     swap(_Tp& __a, _Tp& __b)
      |     ^~~~
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/move.h:189:5: note:   conversion of argument 2 would be ill-formed:
/codemill/bessen/opensource/ips4o/include/ips4o/sampling.hpp:63:13: error: cannot bind non-const lvalue reference of type ‘{anonymous}::FixedStringReference<char, std::__cxx11::basic_string<char> >&’ to an rvalue of type ‘MyIterator::reference’ {aka ‘MyReference’}
   63 |         swap(*begin, begin[i]);
      |         ~~~~^~~~~~~~~~~~~~~~~~
```
To fix that error we can just replace it with `std::iter_swap` which would also use the override I had defined above. This is the fix proposed in this commit.