### PR TITLE
Deterministic Random Generator Initialization

### DIFF
--- a/include/ips4o/memory.hpp
+++ b/include/ips4o/memory.hpp
@@ -193,9 +193,8 @@ struct Sorter<Cfg>::LocalData {
 
     LocalData(typename Cfg::less comp, char* buffer_storage)
         : buffers(buffer_storage), classifier(std::move(comp)) {
-        std::random_device rdev;
-        std::ptrdiff_t seed = rdev();
-        if (Cfg::kIs64Bit) seed = (seed << (Cfg::kIs64Bit * 32)) | rdev();
+        std::ptrdiff_t seed = 3469931;
+        if (Cfg::kIs64Bit) seed = (seed << (Cfg::kIs64Bit * 32)) | (3469931 + 42);
         random_generator.seed(seed);
         reset();
     }


### PR DESCRIPTION
Currently, IPS4O uses `std::random_device` to seed its random generator. While this approach may have certain advantages, it creates challenges for reproducibility in algorithms that depend on IPS4O ...